### PR TITLE
Update copyright name in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Pat B
+Copyright (c) 2025 Patrick Boyle
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request updates the copyright holder's name in the `LICENSE` file to use the full name.

* Changed the copyright holder from "Pat B" to "Patrick Boyle" in `LICENSE`.