### PR TITLE
add validation to relevant tags in drills and upate README to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ All other fields (such as `video`) are optional. For tags, each sub-field is opt
   - `ice_marker`
   - `none`
 
-- `team_drill`: Must be exactly one of:
+- `team_drill`: Must be an array containing exactly one of:
   - `yes`
   - `no`
 

--- a/drills_samples/test-drill-spec/drill.yml
+++ b/drills_samples/test-drill-spec/drill.yml
@@ -18,7 +18,7 @@ images:
 # youtube or vimeo only
 video: https://www.youtube.com/watch?v=dQw4w9WgXcQ
 
-# must be on or before today's date
+# must be a valid calendar date in YYYY-MM-DD format
 drill_creation_date: 2024-01-01
 
 # optional - use if updating existing drill
@@ -30,10 +30,9 @@ tags:
     - beginner
     - intermediate
     - advanced
-  # allowed values: yes or no
+  # allowed values: yes or no (exactly one value)
   team_drill:
     - yes
-    - no
   age_level:
     - all
     - 10U_below

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -134,7 +134,7 @@ function validateDrillData(data: any, drillFolder: string): data is DrillData {
     throw new Error(`[${drillFolder}] drill.yml missing required field 'images' (array)`)
   }
 
-  if (!data.tags || typeof data.tags !== 'object') {
+  if (!data.tags || typeof data.tags !== 'object' || Array.isArray(data.tags)) {
     throw new Error(`[${drillFolder}] drill.yml missing required field 'tags' (object)`)
   }
 
@@ -195,7 +195,7 @@ function validateDrillData(data: any, drillFolder: string): data is DrillData {
   }
 
   if (typeof data.tags.team_drill !== 'undefined' && !Array.isArray(data.tags.team_drill)) {
-    throw new Error(`[${drillFolder}] drill.yml field 'tags.team_drill' must be an array`)
+    throw new Error(`[${drillFolder}] drill.yml field 'tags.team_drill' must be an array of strings`)
   }
   if (Array.isArray(data.tags.team_drill)) {
     if (data.tags.team_drill.length !== 1) {


### PR DESCRIPTION
This pull request introduces stricter validation for drill tag fields in `drill.yml`, ensuring that only predefined values are allowed for certain categories. It also updates the documentation to clearly specify these allowed values and improves repository configuration and CI/CD workflow documentation.

Validation enhancements for drill tag fields:

* Added lists of allowed values for `fundamental_skill`, `skating_skill`, `age_level`, `skill_level`, and `equipment` tags in `gatsby-node.ts` to enforce stricter validation during build time.
* Updated the `validateDrillData` function in `gatsby-node.ts` to throw errors if any tag value does not match the allowed list for these fields.

Documentation updates:

* Expanded the `README.md` to document the allowed values for each tag sub-field and clarify validation behavior, including dynamic aggregation for other tags.
* Added details about USA national colors, TypeScript support, CI/CD workflows, code ownership, Dependabot configuration, and environment variables in the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R187) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R198-R220) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R263-R275)