### PR TITLE
[docs] docs: add drill_creation_date and drill_updated_date to drill.yml field documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,14 +153,14 @@ This project uses a YAML-based drill system with dynamic page generation:
    - `video` (string): YouTube or Vimeo URL for the drill
    - `drill_updated_date` (string): Last updated date in `YYYY-MM-DD` format; must not be earlier than `drill_creation_date`
 
-3. **Dynamic Page Generation**:
+4. **Dynamic Page Generation**:
    - `gatsby-node.ts` handles drill page creation via the `createPages` API
    - Each drill.yml is validated during build
    - Drill data is also added to GraphQL via the `sourceNodes` API
    - The `src/templates/drill.tsx` template is used for all drill pages
    - Build will fail if drill.yml files are invalid or missing required fields
 
-4. **Adding New Drills**:
+5. **Adding New Drills**:
    - Create a new folder in `drills/` with a URL-friendly name
    - Add a `drill.yml` file with all required fields
    - Add drill images to the same folder

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -147,6 +147,11 @@ This project uses a YAML-based drill system with dynamic page generation:
    - `coaching_points` (array): List of coaching tips
    - `images` (array): Array of image filenames
    - `tags` (object): Categorization tags
+   - `drill_creation_date` (string): Creation date in `YYYY-MM-DD` format
+
+3. **Optional drill.yml Fields**:
+   - `video` (string): YouTube or Vimeo URL for the drill
+   - `drill_updated_date` (string): Last updated date in `YYYY-MM-DD` format; must not be earlier than `drill_creation_date`
 
 3. **Dynamic Page Generation**:
    - `gatsby-node.ts` handles drill page creation via the `createPages` API

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ Required fields in drill.yml:
 - `coaching_points`
 - `images`
 - `tags`
-- `drill_creation_date` (string in `YYYY-MM-DD` format, e.g. `2024-01-15`)
+- `drill_creation_date`
 
+`drill_creation_date` is required and must be a string in `YYYY-MM-DD` format (for example, `2024-01-15`).
 All other fields are optional. Known optional fields include:
 
 - `video` — a YouTube or Vimeo URL (see format details below)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ All other fields are optional. Known optional fields include:
 - `video` — a YouTube or Vimeo URL (see format details below)
 - `drill_updated_date` — string in `YYYY-MM-DD` format; must not be earlier than `drill_creation_date`.
 
-For tags, each sub-field is optional, but some sub-fields have restricted allowed values that are validated during build time (in `gatsby-node.ts`):
+The `tags` field is required, but each sub-field is optional. Some sub-fields have restricted allowed values that are validated during build time (in `gatsby-node.ts`):
 
 - `fundamental_skill`: Allowed values are:
   - `skating`

--- a/README.md
+++ b/README.md
@@ -145,8 +145,12 @@ Required fields in drill.yml:
 - coaching_points
 - images
 - tags
+- `drill_creation_date` (string in `YYYY-MM-DD` format, e.g. `2024-01-15`)
 
-All other fields (such as `video`) are optional. For tags, each sub-field is optional, but some sub-fields have restricted allowed values that are validated during build time (in `gatsby-node.ts`):
+All other fields are optional. Known optional fields include:
+
+- `video` — a YouTube or Vimeo URL (see format details below)
+- `drill_updated_date` — string in `YYYY-MM-DD` format; must not be earlier than `drill_creation_date` For tags, each sub-field is optional, but some sub-fields have restricted allowed values that are validated during build time (in `gatsby-node.ts`):
 
 - `fundamental_skill`: Allowed values are:
   - `skating`

--- a/README.md
+++ b/README.md
@@ -140,17 +140,19 @@ To add a new drill for the site, create a new folder under [drills/](drills/) na
 
 Required fields in drill.yml:
 
-- name
-- description
-- coaching_points
-- images
-- tags
+- `name`
+- `description`
+- `coaching_points`
+- `images`
+- `tags`
 - `drill_creation_date` (string in `YYYY-MM-DD` format, e.g. `2024-01-15`)
 
 All other fields are optional. Known optional fields include:
 
 - `video` — a YouTube or Vimeo URL (see format details below)
-- `drill_updated_date` — string in `YYYY-MM-DD` format; must not be earlier than `drill_creation_date` For tags, each sub-field is optional, but some sub-fields have restricted allowed values that are validated during build time (in `gatsby-node.ts`):
+- `drill_updated_date` — string in `YYYY-MM-DD` format; must not be earlier than `drill_creation_date`.
+
+For tags, each sub-field is optional, but some sub-fields have restricted allowed values that are validated during build time (in `gatsby-node.ts`):
 
 - `fundamental_skill`: Allowed values are:
   - `skating`


### PR DESCRIPTION
## Summary

Both `README.md` and `.github/copilot-instructions.md` were missing `drill_creation_date` from the documented required fields of `drill.yml`. The `gatsby-node.ts` build validator enforces this field as required (must be a valid date string in `YYYY-MM-DD` format), so the omission was a genuine inaccuracy that could mislead contributors adding new drills.

`drill_updated_date` was also an undocumented optional field — it has its own validation rules (must be `YYYY-MM-DD`, must not be earlier than `drill_creation_date`).

## Changes

### `README.md`
- Added `drill_creation_date` to the "Required fields in drill.yml" list with its format constraint
- Rewrote the optional-fields note to explicitly list `video` and `drill_updated_date` with descriptions and constraints

### `.github/copilot-instructions.md`
- Added `drill_creation_date` to the **Required drill.yml Fields** list
- Added a new **Optional drill.yml Fields** section documenting `video` and `drill_updated_date`

## Verification

- Changes are documentation-only; no code was modified
- Checked against `gatsby-node.ts` validation logic (lines 230–271) to confirm accuracy
- No workflow files or generated lock files were touched




> Generated by [Update Docs Agent](https://github.com/splk3/goalie-gen/actions/runs/24319647081/agentic_workflow) · ● 502.5K · [◷](https://github.com/search?q=repo%3Asplk3%2Fgoalie-gen+%22gh-aw-workflow-id%3A+update-docs-agent%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs Agent, engine: copilot, model: auto, id: 24319647081, workflow_id: update-docs-agent, run: https://github.com/splk3/goalie-gen/actions/runs/24319647081 -->

<!-- gh-aw-workflow-id: update-docs-agent -->