### PR TITLE
🧪 Add error path test for getVideoThumbnailUrl

### DIFF
--- a/src/utils/__tests__/videoUtils.test.ts
+++ b/src/utils/__tests__/videoUtils.test.ts
@@ -1,4 +1,10 @@
-import { getYouTubeVideoId, getVimeoVideoId, getEmbedUrl, getVideoThumbnail } from "../videoUtils";
+import {
+  getYouTubeVideoId,
+  getVimeoVideoId,
+  getEmbedUrl,
+  getVideoThumbnail,
+  getVideoThumbnailUrl,
+} from "../videoUtils";
 
 describe("getYouTubeVideoId", () => {
   it("extracts video ID from a standard YouTube watch URL", () => {
@@ -75,5 +81,58 @@ describe("getVideoThumbnail", () => {
 
   it("returns empty string for an unrecognised URL", () => {
     expect(getVideoThumbnail("https://example.com/video")).toBe("");
+  });
+});
+
+describe("getVideoThumbnailUrl", () => {
+  const vimeoUrl = "https://vimeo.com/123456789";
+  const youtubeUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+  beforeEach(() => {
+    global.fetch = jest.fn() as any;
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns a YouTube thumbnail URL for a YouTube watch URL", async () => {
+    const url = await getVideoThumbnailUrl(youtubeUrl);
+    expect(url).toBe("https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg");
+  });
+
+  it("returns a Vimeo thumbnail URL for a Vimeo URL when fetch is successful", async () => {
+    const mockThumbnailUrl = "https://vimeo.com/thumb/123.jpg";
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: jest.fn().mockResolvedValue({ thumbnail_url: mockThumbnailUrl }),
+    });
+
+    const url = await getVideoThumbnailUrl(vimeoUrl);
+    expect(url).toBe(mockThumbnailUrl);
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("123456789"));
+  });
+
+  it("returns an empty string and logs an error when Vimeo fetch fails", async () => {
+    const error = new Error("Network error");
+    (global.fetch as jest.Mock).mockRejectedValue(error);
+
+    const url = await getVideoThumbnailUrl(vimeoUrl);
+    expect(url).toBe("");
+    expect(console.error).toHaveBeenCalledWith("Failed to fetch Vimeo thumbnail URL:", error);
+  });
+
+  it("returns an empty string when Vimeo API returns no thumbnail_url", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      json: jest.fn().mockResolvedValue({}),
+    });
+
+    const url = await getVideoThumbnailUrl(vimeoUrl);
+    expect(url).toBe("");
+  });
+
+  it("returns empty string for an unrecognised URL", async () => {
+    const url = await getVideoThumbnailUrl("https://example.com/video");
+    expect(url).toBe("");
   });
 });

--- a/src/utils/__tests__/videoUtils.test.ts
+++ b/src/utils/__tests__/videoUtils.test.ts
@@ -85,54 +85,60 @@ describe("getVideoThumbnail", () => {
 });
 
 describe("getVideoThumbnailUrl", () => {
-  const vimeoUrl = "https://vimeo.com/123456789";
-  const youtubeUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
-    global.fetch = jest.fn() as any;
+    global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
     jest.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
+    global.fetch = originalFetch;
     jest.restoreAllMocks();
   });
 
-  it("returns a YouTube thumbnail URL for a YouTube watch URL", async () => {
-    const url = await getVideoThumbnailUrl(youtubeUrl);
+  it("returns a YouTube thumbnail immediately for a YouTube URL", async () => {
+    const url = await getVideoThumbnailUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
     expect(url).toBe("https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg");
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("returns a Vimeo thumbnail URL for a Vimeo URL when fetch is successful", async () => {
-    const mockThumbnailUrl = "https://vimeo.com/thumb/123.jpg";
-    (global.fetch as jest.Mock).mockResolvedValue({
-      json: jest.fn().mockResolvedValue({ thumbnail_url: mockThumbnailUrl }),
-    });
+  it("fetches and returns a Vimeo thumbnail for a Vimeo URL", async () => {
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      json: async () => ({ thumbnail_url: "https://i.vimeocdn.com/video/12345_640.jpg" }),
+    } as Response);
 
-    const url = await getVideoThumbnailUrl(vimeoUrl);
-    expect(url).toBe(mockThumbnailUrl);
-    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining("123456789"));
+    const url = await getVideoThumbnailUrl("https://vimeo.com/123456789");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://vimeo.com/api/oembed.json?url=https://vimeo.com/123456789"
+    );
+    expect(url).toBe("https://i.vimeocdn.com/video/12345_640.jpg");
   });
 
-  it("returns an empty string and logs an error when Vimeo fetch fails", async () => {
-    const error = new Error("Network error");
-    (global.fetch as jest.Mock).mockRejectedValue(error);
+  it("returns an empty string and logs error if Vimeo fetch fails", async () => {
+    const mockError = new Error("Network error");
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockRejectedValueOnce(mockError);
 
-    const url = await getVideoThumbnailUrl(vimeoUrl);
+    const url = await getVideoThumbnailUrl("https://vimeo.com/123456789");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://vimeo.com/api/oembed.json?url=https://vimeo.com/123456789"
+    );
+    expect(console.error).toHaveBeenCalledWith("Failed to fetch Vimeo thumbnail URL:", mockError);
     expect(url).toBe("");
-    expect(console.error).toHaveBeenCalledWith("Failed to fetch Vimeo thumbnail URL:", error);
   });
 
   it("returns an empty string when Vimeo API returns no thumbnail_url", async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      json: jest.fn().mockResolvedValue({}),
-    });
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      json: async () => ({}),
+    } as Response);
 
-    const url = await getVideoThumbnailUrl(vimeoUrl);
+    const url = await getVideoThumbnailUrl("https://vimeo.com/123456789");
     expect(url).toBe("");
   });
 
-  it("returns empty string for an unrecognised URL", async () => {
+  it("returns an empty string for an unrecognised URL", async () => {
     const url = await getVideoThumbnailUrl("https://example.com/video");
     expect(url).toBe("");
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap in `src/utils/videoUtils.ts` by adding tests for the `getVideoThumbnailUrl` function, specifically focusing on the previously untested error path when fetching Vimeo thumbnails.

📊 **Coverage:**
- YouTube URLs: Verifies it returns the correct YouTube thumbnail URL.
- Vimeo URLs (Success): Mocks a successful fetch call to the Vimeo oEmbed API and verifies it returns the `thumbnail_url`.
- Vimeo URLs (Failure): Mocks a rejected fetch promise to verify that the error is caught, logged to the console, and an empty string is returned.
- Vimeo URLs (Missing Data): Mocks a successful fetch but with an empty JSON object to verify it handles missing expected fields.
- Unrecognized URLs: Verifies it returns an empty string for non-video URLs.

✨ **Result:** Improved test coverage for video utility functions, ensuring robust handling of external API failures when fetching video thumbnails.

---
*PR created automatically by Jules for task [15567989362175132392](https://jules.google.com/task/15567989362175132392) started by @splk3*