### PR TITLE
[docs] docs: add FeedbackButton and pages __tests__ to component listings

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,13 +30,14 @@ The following files and directories are part of the repository:
     - index.tsx, goalie-drills.tsx, team-drills.tsx
     - goalie-resources.tsx, goalie-evals.tsx, coach-resources.tsx, club-resources.tsx
     - 404.tsx
+    - `__tests__/` - Unit tests for pages
   - `src/templates/`: Dynamic page templates (TypeScript .tsx files)
     - drill.tsx - Template for individual drill pages
   - `src/components/`: Reusable React components (TypeScript .tsx files)
     - DarkModeToggle.tsx, Logo.tsx, SEO.tsx
     - GenerateClubPlanButton.tsx, GenerateTeamPlanButton.tsx
     - GoalieJournalButton.tsx, DownloadDrillPdfButton.tsx, DownloadMaterialButton.tsx
-    - ExternalLinkButton.tsx, NavigationButton.tsx, PageLayout.tsx, TermsPopup.tsx
+    - ExternalLinkButton.tsx, FeedbackButton.tsx, NavigationButton.tsx, PageLayout.tsx, TermsPopup.tsx
     - INeedADrillButton.tsx, Pagination.tsx, UsaHockeyGoldBanner.tsx
     - `__tests__/` - Unit tests for components
   - `src/styles/`: Global CSS styles

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The site uses USA national colors:
 │   │   ├── DownloadDrillPdfButton.tsx
 │   │   ├── DownloadMaterialButton.tsx
 │   │   ├── ExternalLinkButton.tsx
+│   │   ├── FeedbackButton.tsx
 │   │   ├── GenerateClubPlanButton.tsx
 │   │   ├── GenerateTeamPlanButton.tsx
 │   │   ├── GoalieJournalButton.tsx
@@ -85,7 +86,8 @@ The site uses USA national colors:
 │   │   ├── goalie-evals.tsx
 │   │   ├── goalie-resources.tsx
 │   │   ├── index.tsx
-│   │   └── team-drills.tsx
+│   │   ├── team-drills.tsx
+│   │   └── __tests__/     # Unit tests for pages
 │   ├── templates/        # Dynamic page templates
 │   │   └── drill.tsx     # Template for individual drill pages
 │   ├── styles/           # Global CSS styles


### PR DESCRIPTION
## Summary

Two documentation gaps found and fixed:

### 1. Missing `FeedbackButton.tsx` in component listings

`src/components/FeedbackButton.tsx` exists in the codebase but was absent from both:
- The **Project Structure** tree in `README.md`
- The **Repository Structure** component list in `.github/copilot-instructions.md`

`FeedbackButton` is a modal dialog component that lets users report bugs, request features, or submit new drill suggestions via GitHub issue templates.

### 2. Missing `src/pages/__tests__/` in directory docs

`src/pages/__tests__/` exists (containing `goalie-drills.test.tsx`) but was not documented in either file, even though the equivalent `__tests__/` directories under `src/components/`, `src/hooks/`, and `src/utils/` are all documented.

## Files Changed

- `README.md` — Added `FeedbackButton.tsx` to the components tree; added `__tests__/` entry to the pages tree
- `.github/copilot-instructions.md` — Added `FeedbackButton.tsx` to the components inline list; added `__tests__/` entry under `src/pages/`

## What was NOT changed

- No workflow files were modified
- No generated lockfiles were touched
- No structural or stylistic rewrites — changes are minimal and surgical




> Generated by [Update Docs Agent](https://github.com/splk3/goalie-gen/actions/runs/25264136534/agentic_workflow) · ● 751.7K · [◷](https://github.com/search?q=repo%3Asplk3%2Fgoalie-gen+%22gh-aw-workflow-id%3A+update-docs-agent%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs Agent, engine: copilot, model: auto, id: 25264136534, workflow_id: update-docs-agent, run: https://github.com/splk3/goalie-gen/actions/runs/25264136534 -->

<!-- gh-aw-workflow-id: update-docs-agent -->