### PR TITLE
[docs] Update docs: fix field name and add missing components, utils, content directory

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ The following files and directories are part of the repository:
     - GoalieJournalButton.tsx, DownloadDrillPdfButton.tsx, DownloadMaterialButton.tsx
     - ExternalLinkButton.tsx, NavigationButton.tsx, PageLayout.tsx, TermsPopup.tsx
     - INeedADrillButton.tsx, Pagination.tsx, UsaHockeyGoldBanner.tsx
+    - FeedbackButton.tsx, FormatSelector.tsx, ImageUploader.tsx, Modal.tsx
     - `__tests__/` - Unit tests for components
   - `src/styles/`: Global CSS styles
   - `src/hooks/`: Custom React hooks (e.g., useDrillFilters.ts)
@@ -45,7 +46,13 @@ The following files and directories are part of the repository:
   - `src/types/`: TypeScript type definitions
     - drill.ts - `DrillData` interface used by gatsby-node.ts and templates
   - `src/declarations.d.ts`: Module declarations (e.g., CSS module imports)
-  - `src/utils/`: Utility functions (e.g., analytics.ts, generateDrillPdf.ts, videoUtils.ts)
+  - `src/content/`: Markdown content files used for plan and journal generation
+    - `club-plan/` - Club development plan section content
+    - `goalie-journal/` - Goalie journal section content
+    - `team-plan/` - Team development plan section content
+  - `src/utils/`: Utility functions (e.g., analytics.ts, generateDrillPdf.ts, videoUtils.ts,
+    docxContent.ts, markdownParser.ts, normalizeDrillDescription.ts, staticAsset.ts,
+    estimateDrillPdfPages.ts, loadExportModules.ts)
     - `__tests__/` - Unit tests for utilities
 - `drills/`: Drill database (YAML-based drill definitions with images)
   - Each subdirectory contains a drill.yml and associated images

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,9 +50,9 @@ The following files and directories are part of the repository:
     - `club-plan/` - Club development plan section content
     - `goalie-journal/` - Goalie journal section content
     - `team-plan/` - Team development plan section content
-  - `src/utils/`: Utility functions (e.g., analytics.ts, generateDrillPdf.ts, videoUtils.ts,
-    docxContent.ts, markdownParser.ts, normalizeDrillDescription.ts, staticAsset.ts,
-    estimateDrillPdfPages.ts, loadExportModules.ts)
+  - `src/utils/`: Utility functions (analytics.ts, docxContent.ts, estimateDrillPdfPages.ts,
+    generateDrillPdf.ts, loadExportModules.ts, markdownParser.ts, normalizeDrillDescription.ts,
+    staticAsset.ts, videoUtils.ts)
     - `__tests__/` - Unit tests for utilities
 - `drills/`: Drill database (YAML-based drill definitions with images)
   - Each subdirectory contains a drill.yml and associated images

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The site uses USA national colors:
 │   ├── types/            # TypeScript type definitions
 │   │   └── drill.ts      # DrillData interface
 │   ├── declarations.d.ts # Module declarations (e.g., CSS modules)
-│   ├── content/          # Markdown content for plan generation
+│   ├── content/          # Markdown content for plan and journal generation
 │   │   ├── club-plan/    # Club development plan sections
 │   │   ├── goalie-journal/ # Goalie journal sections
 │   │   └── team-plan/    # Team development plan sections

--- a/README.md
+++ b/README.md
@@ -65,11 +65,15 @@ The site uses USA national colors:
 │   │   ├── DownloadDrillPdfButton.tsx
 │   │   ├── DownloadMaterialButton.tsx
 │   │   ├── ExternalLinkButton.tsx
+│   │   ├── FeedbackButton.tsx
+│   │   ├── FormatSelector.tsx
 │   │   ├── GenerateClubPlanButton.tsx
 │   │   ├── GenerateTeamPlanButton.tsx
 │   │   ├── GoalieJournalButton.tsx
 │   │   ├── INeedADrillButton.tsx
+│   │   ├── ImageUploader.tsx
 │   │   ├── Logo.tsx
+│   │   ├── Modal.tsx
 │   │   ├── NavigationButton.tsx
 │   │   ├── PageLayout.tsx
 │   │   ├── Pagination.tsx
@@ -95,16 +99,28 @@ The site uses USA national colors:
 │   ├── types/            # TypeScript type definitions
 │   │   └── drill.ts      # DrillData interface
 │   ├── declarations.d.ts # Module declarations (e.g., CSS modules)
+│   ├── content/          # Markdown content for plan generation
+│   │   ├── club-plan/    # Club development plan sections
+│   │   ├── goalie-journal/ # Goalie journal sections
+│   │   └── team-plan/    # Team development plan sections
 │   └── utils/            # Utility functions
 │       ├── analytics.ts
+│       ├── docxContent.ts
+│       ├── estimateDrillPdfPages.ts
 │       ├── generateDrillPdf.ts
+│       ├── loadExportModules.ts
+│       ├── markdownParser.ts
+│       ├── normalizeDrillDescription.ts
+│       ├── staticAsset.ts
 │       ├── videoUtils.ts
 │       └── __tests__/     # Unit tests for utilities
 ├── drills/               # Drill database (YAML + images)
 │   ├── power-push-quick-movement-blaze-pods/
+│   ├── rim-stop-cut-across/
 │   ├── test-drill-advanced-teams/
 │   ├── test-drill-beginner/
-│   └── test-drill-intermediate/
+│   ├── test-drill-intermediate/
+│   └── test-drill-max-content/
 ├── drills_samples/       # Drill specification examples
 ├── static/               # Static assets
 │   ├── CNAME            # Custom domain configuration
@@ -153,7 +169,7 @@ Required fields in drill.yml:
 
 - `name`
 - `description`
-- `coaching_points`
+- `coaching_focus_points`
 - `images`
 - `tags`
 - `drill_creation_date`


### PR DESCRIPTION
## Summary

This PR updates `README.md` and `.github/copilot-instructions.md` to accurately reflect the current state of the codebase.

## Changes

### `README.md`

- **Fixed** required `drill.yml` field name: `coaching_points` → `coaching_focus_points` (the actual field name used in all drill YAML files)
- **Added** missing components to the project structure tree: `FeedbackButton.tsx`, `FormatSelector.tsx`, `ImageUploader.tsx`, `Modal.tsx`
- **Added** missing utility files to the project structure tree: `docxContent.ts`, `estimateDrillPdfPages.ts`, `loadExportModules.ts`, `markdownParser.ts`, `normalizeDrillDescription.ts`, `staticAsset.ts`
- **Added** `src/content/` directory (containing Markdown content for club-plan, goalie-journal, and team-plan generation)
- **Added** missing drill folders to the drills listing: `rim-stop-cut-across/` and `test-drill-max-content/`

### `.github/copilot-instructions.md`

- **Added** same missing components to the component listing
- **Added** same missing utilities to the utils listing
- **Added** `src/content/` directory description

## Files Modified

- `README.md`
- `.github/copilot-instructions.md`

No workflow files or generated lockfiles were modified.




> Generated by [Update Docs Agent](https://github.com/splk3/goalie-gen/actions/runs/25953178316/agentic_workflow) · ● 7.3M · [◷](https://github.com/search?q=repo%3Asplk3%2Fgoalie-gen+%22gh-aw-workflow-id%3A+update-docs-agent%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs Agent, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25953178316, workflow_id: update-docs-agent, run: https://github.com/splk3/goalie-gen/actions/runs/25953178316 -->

<!-- gh-aw-workflow-id: update-docs-agent -->