### PR TITLE
[docs] Update README to reflect current repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The site uses USA national colors:
 ```text
 ├── src/
 │   ├── components/       # React components (TypeScript)
+│   │   ├── BackLinkButton.tsx
 │   │   ├── DarkModeToggle.tsx
 │   │   ├── DownloadDrillPdfButton.tsx
 │   │   ├── DownloadMaterialButton.tsx
@@ -70,6 +71,7 @@ The site uses USA national colors:
 │   │   ├── GenerateClubPlanButton.tsx
 │   │   ├── GenerateTeamPlanButton.tsx
 │   │   ├── GoalieJournalButton.tsx
+│   │   ├── HamburgerMenu.tsx
 │   │   ├── INeedADrillButton.tsx
 │   │   ├── ImageUploader.tsx
 │   │   ├── Logo.tsx
@@ -78,6 +80,7 @@ The site uses USA national colors:
 │   │   ├── PageLayout.tsx
 │   │   ├── Pagination.tsx
 │   │   ├── SEO.tsx
+│   │   ├── ShareButton.tsx
 │   │   ├── TermsPopup.tsx
 │   │   ├── UsaHockeyGoldBanner.tsx
 │   │   └── __tests__/     # Unit tests for components
@@ -121,7 +124,7 @@ The site uses USA national colors:
 │   ├── test-drill-beginner/
 │   ├── test-drill-intermediate/
 │   └── test-drill-max-content/
-├── drills_samples/       # Drill specification examples
+├── drill-spec-example/   # Drill specification example
 ├── static/               # Static assets
 │   ├── CNAME            # Custom domain configuration
 │   ├── favicons/        # Site icons
@@ -156,7 +159,7 @@ The site uses USA national colors:
 
 ## 🧊 Drills
 
-Drill examples live in [drills_samples/](drills_samples/) and the full field specification is in [drills_samples/test-drill-spec/drill.yml](drills_samples/test-drill-spec/drill.yml).
+Drill examples live in [drill-spec-example/](drill-spec-example/) and the full field specification is in [drill-spec-example/drill.yml](drill-spec-example/drill.yml).
 
 Active drills that appear on the site are in the [drills/](drills/) directory. Each drill gets its own dynamically generated page at `/drills/{drill-folder-name}` via the `gatsby-node.ts` configuration.
 


### PR DESCRIPTION
## Summary

Three factual inaccuracies were found in `README.md` and corrected:

1. **Wrong directory name for drill spec examples** — The README referenced `drills_samples/` and `drills_samples/test-drill-spec/drill.yml`, but the actual directory is `drill-spec-example/` with the spec at `drill-spec-example/drill.yml`.

2. **Missing components in project structure listing** — Three components present in `src/components/` were absent from the README's file tree:
   - `BackLinkButton.tsx`
   - `HamburgerMenu.tsx`
   - `ShareButton.tsx`

No changes were made to `.github/copilot-instructions.md` as it was found to be accurate.




> Generated by [Update Docs Agent](https://github.com/splk3/goalie-gen/actions/runs/26323942151) · ● 4.1M · [◷](https://github.com/search?q=repo%3Asplk3%2Fgoalie-gen+%22gh-aw-workflow-id%3A+update-docs-agent%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs Agent, engine: copilot, version: 1.0.48, model: claude-sonnet-4.6, id: 26323942151, workflow_id: update-docs-agent, run: https://github.com/splk3/goalie-gen/actions/runs/26323942151 -->

<!-- gh-aw-workflow-id: update-docs-agent -->