### PR TITLE
[docs] Update README to reflect current repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ The site uses USA national colors:
 │   │   └── team-plan/    # Team development plan sections
 │   └── utils/            # Utility functions
 │       ├── analytics.ts
+│       ├── coachingFocusPoints.ts
 │       ├── docxContent.ts
+│       ├── docxImageType.ts
+│       ├── drillPdfPaginationShared.ts
 │       ├── estimateDrillPdfPages.ts
 │       ├── generateDrillPdf.ts
 │       ├── loadExportModules.ts
@@ -147,12 +150,16 @@ The site uses USA national colors:
 │       ├── videoUtils.ts
 │       └── __tests__/     # Unit tests for utilities
 ├── drills/               # Drill database (YAML + images)
-│   ├── power-push-quick-movement-blaze-pods/
+│   ├── beat-the-pass/
+│   ├── butterfly-map-series/
+│   ├── crease-footwork/
+│   ├── reaction-shot-read/
+│   ├── read-and-react/
+│   ├── rim-and-shot/
 │   ├── rim-stop-cut-across/
-│   ├── test-drill-advanced-teams/
-│   ├── test-drill-beginner/
-│   ├── test-drill-intermediate/
-│   └── test-drill-max-content/
+│   ├── rvh-low-to-high-release/
+│   ├── shot-rebound-recovery/
+│   └── two-shot/
 ├── drill-spec-example/   # Drill specification example
 ├── static/               # Static assets
 │   ├── CNAME            # Custom domain configuration


### PR DESCRIPTION
## Summary

This PR updates `README.md` to accurately reflect the current state of the repository.

### Changes

**`drills/` directory listing** — replaced stale test drill entries with the actual production drills now in the repo:

| Removed | Added |
|---|---|
| `power-push-quick-movement-blaze-pods/` | `beat-the-pass/` |
| `test-drill-advanced-teams/` | `butterfly-map-series/` |
| `test-drill-beginner/` | `crease-footwork/` |
| `test-drill-intermediate/` | `reaction-shot-read/` |
| `test-drill-max-content/` | `read-and-react/` |
| | `rim-and-shot/` |
| | `rvh-low-to-high-release/` |
| | `shot-rebound-recovery/` |
| | `two-shot/` |
| _(kept)_ `rim-stop-cut-across/` | `rim-stop-cut-across/` |

**`src/utils/` directory listing** — added three utility files that exist on disk but were missing from the docs:
- `coachingFocusPoints.ts`
- `docxImageType.ts`
- `drillPdfPaginationShared.ts` (was already referenced in the PDF pagination notes section but omitted from the directory tree)

No other documentation was changed. `copilot-instructions.md` was reviewed and remains accurate.




> Generated by [Update Docs Agent](https://github.com/splk3/goalie-gen/actions/runs/26675136108) · ● 3M · [◷](https://github.com/search?q=repo%3Asplk3%2Fgoalie-gen+%22gh-aw-workflow-id%3A+update-docs-agent%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Update Docs Agent, engine: copilot, version: 1.0.48, model: claude-sonnet-4.6, id: 26675136108, workflow_id: update-docs-agent, run: https://github.com/splk3/goalie-gen/actions/runs/26675136108 -->

<!-- gh-aw-workflow-id: update-docs-agent -->