### PR TITLE
599 add content for jk project page

### DIFF
--- a/src/pages/__tests__/about-pages.test.tsx
+++ b/src/pages/__tests__/about-pages.test.tsx
@@ -386,7 +386,7 @@ describe("About pages", () => {
     it("renders the presentation viewer and download button", () => {
       expect(screen.getByTitle("Patrick Boyle presentation PDF")).toHaveAttribute(
         "src",
-        "/presentations/patrick-presentation.pdf?v=1"
+        "/presentations/patrick-presentation.pdf?v=1#navpanes=0&view=Fit"
       );
       expect(
         screen.getByRole("button", { name: "Download Patrick Boyle Presentation" })
@@ -439,8 +439,24 @@ describe("About pages", () => {
       ).toBeInTheDocument();
     });
 
-    it("renders the Content Coming Soon notice", () => {
-      expect(screen.getByText(/Content Coming Soon!/i)).toBeInTheDocument();
+    it("does not render the Content Coming Soon notice", () => {
+      expect(screen.queryByText(/Content Coming Soon!/i)).not.toBeInTheDocument();
+    });
+
+    it("renders the presentation viewer and download controls", () => {
+      expect(screen.getByTitle("James Kujawski presentation PDF")).toHaveAttribute(
+        "src",
+        "/presentations/james-kujawski-presentation-no-videos.pdf?v=1#navpanes=0&view=Fit"
+      );
+      expect(
+        screen.getByRole("button", { name: "Download Presentation (No Videos)" })
+      ).toHaveAttribute("data-file-name", "james-kujawski-presentation-no-videos.pdf");
+      expect(
+        screen.getByRole("link", { name: "Download Full Presentation (Videos Included)" })
+      ).toHaveAttribute(
+        "href",
+        "https://docs.google.com/presentation/d/1afi7C1_RCYAZBWF8VfPIM0WuVhKEPyDz/export/pptx"
+      );
     });
 
     it("renders a Back to Home link", () => {

--- a/src/pages/james-kujawski-project.tsx
+++ b/src/pages/james-kujawski-project.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
+import { withPrefix } from "gatsby";
 import Seo from "../components/SEO";
 import AboutPage from "../components/AboutPage";
+import DownloadMaterialButton from "../components/DownloadMaterialButton";
 import rawMarkdown from "../content/about/james-kujawski-project/index.md";
+import { buildCacheBustedAssetPath } from "../utils/staticAsset";
+
+const FULL_PRESENTATION_URL =
+  "https://docs.google.com/presentation/d/1VRtMJf45p7te7KPD09N2qXafcv7wunJ7/edit?usp=sharing&ouid=116610288340277897255&rtpof=true&sd=true";
 
 export default function JamesKujawskiProject() {
   return (
@@ -9,6 +15,44 @@ export default function JamesKujawskiProject() {
       title="James Kujawski's Project"
       subtitle="Modernizing Goalie Drill Design using a constraints-led approach and flexible, progression and options-based adaptability."
       rawMarkdown={rawMarkdown}
+      showComingSoonNotice={false}
+      topCta={
+        <div className="space-y-6 text-left">
+          <div>
+            <h2 className="text-2xl font-bold text-usa-blue dark:text-blue-400">
+              James Kujawski Presentation
+            </h2>
+            <p className="mt-2 text-gray-700 dark:text-gray-300">
+              View the slide deck below or download it for offline use.
+            </p>
+          </div>
+          <iframe
+            src={withPrefix(
+              buildCacheBustedAssetPath(
+                "/presentations/james-kujawski-presentation-no-videos.pdf"
+              )
+            )}
+            title="James Kujawski presentation PDF"
+            className="h-[70vh] min-h-[30rem] w-full rounded-lg border border-gray-300 shadow-lg dark:border-gray-600"
+          />
+          <div className="space-y-3">
+            <DownloadMaterialButton
+              title="Download Presentation (No Videos)"
+              fileName="james-kujawski-presentation-no-videos.pdf"
+              folder="presentations"
+            />
+            <a
+              href={FULL_PRESENTATION_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block w-full bg-usa-red hover:bg-red-800 dark:bg-red-600 dark:hover:bg-red-700 text-usa-white font-bold py-4 px-8 rounded-lg text-xl shadow-lg transition-colors transform hover:scale-105 text-center"
+              aria-label="Download Full Presentation (Videos Included)"
+            >
+              Download Full Presentation (Videos Included)
+            </a>
+          </div>
+        </div>
+      }
     />
   );
 }

--- a/src/pages/james-kujawski-project.tsx
+++ b/src/pages/james-kujawski-project.tsx
@@ -7,7 +7,7 @@ import rawMarkdown from "../content/about/james-kujawski-project/index.md";
 import { buildCacheBustedAssetPath } from "../utils/staticAsset";
 
 const FULL_PRESENTATION_URL =
-  "https://docs.google.com/presentation/d/1afi7C1_RCYAZBWF8VfPIM0WuVhKEPyDz/edit?usp=sharing&ouid=116610288340277897255&rtpof=true&sd=true";
+  "https://docs.google.com/presentation/d/1afi7C1_RCYAZBWF8VfPIM0WuVhKEPyDz/export/pptx";
 
 export default function JamesKujawskiProject() {
   return (
@@ -27,11 +27,7 @@ export default function JamesKujawskiProject() {
             </p>
           </div>
           <iframe
-            src={withPrefix(
-              buildCacheBustedAssetPath(
-                "/presentations/james-kujawski-presentation-no-videos.pdf"
-              )
-            )}
+            src={`${withPrefix(buildCacheBustedAssetPath("/presentations/james-kujawski-presentation-no-videos.pdf"))}#navpanes=0&view=Fit`}
             title="James Kujawski presentation PDF"
             className="h-[70vh] min-h-[30rem] w-full rounded-lg border border-gray-300 shadow-lg dark:border-gray-600"
           />

--- a/src/pages/james-kujawski-project.tsx
+++ b/src/pages/james-kujawski-project.tsx
@@ -7,7 +7,7 @@ import rawMarkdown from "../content/about/james-kujawski-project/index.md";
 import { buildCacheBustedAssetPath } from "../utils/staticAsset";
 
 const FULL_PRESENTATION_URL =
-  "https://docs.google.com/presentation/d/1VRtMJf45p7te7KPD09N2qXafcv7wunJ7/edit?usp=sharing&ouid=116610288340277897255&rtpof=true&sd=true";
+  "https://docs.google.com/presentation/d/1afi7C1_RCYAZBWF8VfPIM0WuVhKEPyDz/edit?usp=sharing&ouid=116610288340277897255&rtpof=true&sd=true";
 
 export default function JamesKujawskiProject() {
   return (

--- a/src/pages/katie-jablynski-project.tsx
+++ b/src/pages/katie-jablynski-project.tsx
@@ -24,7 +24,7 @@ export default function KatieJablynskiProject() {
             </p>
           </div>
           <iframe
-            src={withPrefix(buildCacheBustedAssetPath("/presentations/katie-gold-presenation.pdf"))}
+            src={`${withPrefix(buildCacheBustedAssetPath("/presentations/katie-gold-presenation.pdf"))}#navpanes=0&view=Fit`}
             title="Katie Jablynski presentation PDF"
             className="h-[70vh] min-h-[30rem] w-full rounded-lg border border-gray-300 shadow-lg dark:border-gray-600"
           />

--- a/src/pages/patrick-boyle-project.tsx
+++ b/src/pages/patrick-boyle-project.tsx
@@ -24,7 +24,7 @@ export default function PatrickBoyleProject() {
             </p>
           </div>
           <iframe
-            src={withPrefix(buildCacheBustedAssetPath("/presentations/patrick-presentation.pdf"))}
+            src={`${withPrefix(buildCacheBustedAssetPath("/presentations/patrick-presentation.pdf"))}#navpanes=0&view=Fit`}
             title="Patrick Boyle presentation PDF"
             className="h-[70vh] min-h-[30rem] w-full rounded-lg border border-gray-300 shadow-lg dark:border-gray-600"
           />


### PR DESCRIPTION
This pull request enhances the presentation pages for James Kujawski, Katie Jablynski, and Patrick Boyle by improving the presentation PDF viewing experience and adding new download options for the James Kujawski project. The most important changes are grouped below.

**New features and download options:**

* Added a prominent section at the top of the `JamesKujawskiProject` page featuring an embedded PDF viewer, a button to download the presentation without videos, and a link to download the full presentation with videos included. (`src/pages/james-kujawski-project.tsx`)

**User experience improvements for PDF viewing:**

* Updated the embedded PDF viewers on the James Kujawski, Katie Jablynski, and Patrick Boyle project pages to open PDFs with navigation panes hidden and the view set to fit the window, providing a cleaner and more user-friendly display. (`src/pages/james-kujawski-project.tsx`, `src/pages/katie-jablynski-project.tsx`, `src/pages/patrick-boyle-project.tsx`) [[1]](diffhunk://#diff-190877e07f61790a07bd0d76df08965c3cc7536cdc25a1625fa43f42976ad412R2-R51) [[2]](diffhunk://#diff-9cc0b7f56335323e8f024c16e28bcede254ae6c8239962c12711ddc11e0cd16eL27-R27) [[3]](diffhunk://#diff-42e5cb785c9044a5615047fa63a45e57916fbce3e91480c1a8706267b7f63ce2L27-R27)