### PR TITLE
add email signup button component and integrate it into the home page

### DIFF
--- a/src/components/EmailSignupButton.tsx
+++ b/src/components/EmailSignupButton.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import Modal from "./Modal";
+
+const KIT_EMBED_SRC = "https://goaliegen.kit.com/b608e069fe/index.js";
+const KIT_EMBED_UID = "b608e069fe";
+
+export default function EmailSignupButton() {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const formContainerRef = React.useRef<HTMLDivElement>(null);
+  const hasLoadedFormRef = React.useRef<boolean>(false);
+
+  const openSignup = () => setIsOpen(true);
+  const closeSignup = () => setIsOpen(false);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeSignup();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  React.useEffect(() => {
+    if (!isOpen || !formContainerRef.current || hasLoadedFormRef.current) return;
+
+    const container = formContainerRef.current;
+    const script = document.createElement("script");
+    script.async = true;
+    script.setAttribute("data-uid", KIT_EMBED_UID);
+    script.src = KIT_EMBED_SRC;
+    container.appendChild(script);
+    hasLoadedFormRef.current = true;
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        onClick={openSignup}
+        className="inline-flex items-center justify-center rounded-md border border-white/40 bg-transparent px-3 py-1.5 text-sm font-medium text-white/90 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-usa-blue dark:border-gray-500 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white dark:focus-visible:ring-offset-gray-800"
+      >
+        Get Email Updates
+      </button>
+
+      <Modal
+        isOpen={isOpen}
+        labelledBy="email-signup-heading"
+        className="max-w-lg w-full"
+        triggerRef={triggerRef}
+        keepMounted={true}
+      >
+        <div className="p-6 overflow-y-auto flex-1 min-h-0">
+          <h2
+            id="email-signup-heading"
+            className="text-2xl font-bold text-usa-blue dark:text-blue-400 mb-4"
+          >
+            Sign Up for Email Updates
+          </h2>
+          <div ref={formContainerRef} />
+        </div>
+        <div className="px-6 pb-6 flex-shrink-0">
+          <button
+            onClick={closeSignup}
+            className="w-full text-center text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -9,6 +9,7 @@ interface ModalProps {
   children: React.ReactNode;
   className?: string;
   triggerRef?: React.RefObject<HTMLElement | null>;
+  keepMounted?: boolean;
 }
 
 /**
@@ -31,6 +32,7 @@ export default function Modal({
   children,
   className = "",
   triggerRef,
+  keepMounted = false,
 }: ModalProps) {
   const dialogRef = React.useRef<HTMLDivElement>(null);
   const wasOpenRef = React.useRef<boolean>(false);
@@ -85,14 +87,17 @@ export default function Modal({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen]);
 
-  if (!isOpen) return null;
+  if (!isOpen && !keepMounted) return null;
 
   return (
     <>
       {/* Visual overlay — purely decorative, hidden from assistive technology */}
-      <div aria-hidden="true" className="fixed inset-0 bg-black/75 z-50" />
+      <div
+        aria-hidden="true"
+        className={`fixed inset-0 bg-black/75 z-50 ${isOpen ? "" : "hidden"}`}
+      />
       {/* Dialog centering container */}
-      <div className="fixed inset-0 flex items-center justify-center p-4 z-50">
+      <div className={`fixed inset-0 p-4 z-50 ${isOpen ? "flex items-center justify-center" : "hidden"}`}>
         <div
           ref={dialogRef}
           tabIndex={-1}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,6 +11,7 @@ import INeedADrillButton from "../components/INeedADrillButton";
 import NavigationButton from "../components/NavigationButton";
 import TermsPopup from "../components/TermsPopup";
 import FeedbackButton from "../components/FeedbackButton";
+import EmailSignupButton from "../components/EmailSignupButton";
 import UsaHockeyGoldBanner from "../components/UsaHockeyGoldBanner";
 import ShareButton from "../components/ShareButton";
 
@@ -266,6 +267,7 @@ export default function Home() {
               <div className="mt-2 flex items-center justify-center gap-3">
                 <TermsPopup />
                 <FeedbackButton />
+                <EmailSignupButton />
               </div>
             </div>
           </div>


### PR DESCRIPTION
This pull request introduces a new email signup feature and makes related improvements to the modal component to support persistent mounting. The main changes include adding an `EmailSignupButton` component that opens a modal with an embedded signup form, updating the `Modal` component to allow it to remain mounted in the DOM, and integrating the new button into the homepage.

**Email Signup Feature:**

* Added a new `EmailSignupButton` component that opens a modal containing an embedded signup form loaded via an external script. The modal supports keyboard accessibility and ensures the form is loaded only once. (`src/components/EmailSignupButton.tsx`)
* Integrated the `EmailSignupButton` into the homepage by importing it and adding it to the action button row. (`src/pages/index.tsx`) [[1]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R14) [[2]](diffhunk://#diff-18e0d4553c97cfc420e938ccafb4e3a688e782fa4512ba4ceae3e2a6f24c1987R270)

**Modal Component Enhancements:**

* Added a `keepMounted` prop to the `Modal` component, allowing the modal's DOM to remain mounted even when not visible. This is necessary for cases where child components/scripts need to persist. (`src/components/Modal.tsx`) [[1]](diffhunk://#diff-f483ed13f83c85dfd7d0487b9efbe9288e5feba94e8a53ee91011582c28713fdR12) [[2]](diffhunk://#diff-f483ed13f83c85dfd7d0487b9efbe9288e5feba94e8a53ee91011582c28713fdR35)
* Updated the modal's rendering logic to use the `keepMounted` prop and to toggle visibility using CSS classes instead of unmounting from the DOM. (`src/components/Modal.tsx`)